### PR TITLE
Fix default Linux music path

### DIFF
--- a/lib/core/configuration.dart
+++ b/lib/core/configuration.dart
@@ -33,7 +33,7 @@ Map<String, dynamic> DEFAULT_CONFIGURATION = {
   'collectionDirectories': <String>[
     {
       'windows': () => path.join(Platform.environment['USERPROFILE']!, 'Music'),
-      'linux': () => path.join(Platform.environment['HOME']!, 'Music'),
+      'linux': () => path.join(Platform.environment['HOME']!, Process.runSync('xdg-user-dir', ['MUSIC']).stdout.toString()),
       'android': () => '/storage/emulated/0/Music',
     }[Platform.operatingSystem]!(),
   ],


### PR DESCRIPTION
The default Linux music path is /home/$USER/Music, in my case, it's wrong, cause my folder is in french 
![image](https://user-images.githubusercontent.com/43904633/136291920-0ca6264d-79e5-4b31-a032-4a1b4c846443.png)

To avoid this error, the command `xdg-user-dir MUSIC` returns the music folder of the system
![image](https://user-images.githubusercontent.com/43904633/136292235-4a4b72a7-893c-4d79-8158-8c6f6bfd7b06.png)

