### PR TITLE
Migrate to Flutter Android Embedding v2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     <application
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="Harmonoid"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Due to [this](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects) it wouldn't build for me on latest Flutter beta version