### PR TITLE
[Windows] Delete the .harmonoid folder during uninstall

### DIFF
--- a/Harmonoid_InnoSetup.iss
+++ b/Harmonoid_InnoSetup.iss
@@ -145,3 +145,5 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
+[UninstallDelete]
+Type: filesandordirs; Name: "{%USERPROFILE}\.harmonoid"


### PR DESCRIPTION
Honestly, I haven't tested it, but it should work fine. I don't know if it's possible to do the same for Linux packages.