### PR TITLE
refactor: music indexing logic & cache management 

### DIFF
--- a/lib/core/collection.dart
+++ b/lib/core/collection.dart
@@ -58,20 +58,20 @@ class Collection extends ChangeNotifier {
     }
   }
 
+  List<Album> albums = [];
+  List<Track> tracks = [];
+  List<Artist> artists = [];
+  List<Playlist> playlists = <Playlist>[];
+
   late List<Directory> collectionDirectories;
   late Directory cacheDirectory;
   late CollectionSort collectionSortType;
   late CollectionOrder collectionOrderType;
   late Directory albumArtDirectory;
   late File unknownAlbumArt;
-  List<Playlist> playlists = <Playlist>[];
-  List<Album> albums = <Album>[];
-  List<Track> tracks = <Track>[];
-  List<Artist> artists = <Artist>[];
-  List<String> files = <String>[];
+
   SplayTreeMap<AlbumArtist, List<Album>> albumArtists =
       SplayTreeMap<AlbumArtist, List<Album>>();
-  bool _refreshing = false;
 
   /// Adds new directories that will be used for indexing of the music.
   ///
@@ -145,9 +145,10 @@ class Collection extends ChangeNotifier {
     for (final directory in directories) {
       collectionDirectories.remove(directory);
     }
-    final current = <Track>[];
-    for (int i = 0; i < tracks.length; i++) {
-      final track = tracks[i];
+    final current = HashSet<Track>();
+    int i = 0;
+    for (final element in _tracks) {
+      final track = element;
       bool present = false;
       for (final directory in collectionDirectories) {
         if (track.uri.toFilePath().startsWith(directory.path)) {
@@ -159,12 +160,13 @@ class Collection extends ChangeNotifier {
         current.add(track);
       }
       try {
-        onProgress?.call(i + 1, tracks.length, i + 1 == tracks.length);
-      } catch (exception) {}
+        onProgress?.call(i + 1, _tracks.length, i + 1 == _tracks.length);
+        i++;
+      } catch (_) {}
     }
     try {
-      onProgress?.call(tracks.length, tracks.length, true);
-      tracks = current;
+      onProgress?.call(_tracks.length, _tracks.length, true);
+      _tracks = current;
       await saveToCache();
       await sort();
       await refresh();
@@ -179,21 +181,21 @@ class Collection extends ChangeNotifier {
 
     List<Media> result = <Media>[];
     if (mode is Album || mode == null) {
-      for (Album album in albums) {
+      for (Album album in _albums) {
         if (album.albumName.toLowerCase().contains(query.toLowerCase())) {
           result.add(album);
         }
       }
     }
     if (mode is Track || mode == null) {
-      for (Track track in tracks) {
+      for (Track track in _tracks) {
         if (track.trackName.toLowerCase().contains(query.toLowerCase())) {
           result.add(track);
         }
       }
     }
     if (mode is Artist || mode == null) {
-      for (Artist artist in artists) {
+      for (Artist artist in _artists) {
         if (artist.artistName.toLowerCase().contains(query.toLowerCase())) {
           result.add(artist);
         }
@@ -210,14 +212,7 @@ class Collection extends ChangeNotifier {
     required File file,
     bool notifyListeners: true,
   }) async {
-    bool isAlreadyPresent = false;
-    for (final track in tracks) {
-      if (track.uri.toFilePath() == file.uri.toFilePath()) {
-        isAlreadyPresent = true;
-        break;
-      }
-    }
-    if (kSupportedFileTypes.contains(file.extension) && !isAlreadyPresent) {
+    if (kSupportedFileTypes.contains(file.extension)) {
       try {
         final metadata = <String, dynamic>{
           'uri': file.uri.toString(),
@@ -267,23 +262,16 @@ class Collection extends ChangeNotifier {
   ///
   Future<void> delete(Media object, {bool delete: true}) async {
     if (object is Track) {
-      for (int index = 0; index < tracks.length; index++) {
-        if (object.uri.toFilePath() == tracks[index].uri.toFilePath()) {
-          tracks.removeAt(index);
-          break;
-        }
-      }
-      for (int i = 0; i < albums.length; i++) {
-        final album = albums[i];
+      _tracks.remove(object);
+      for (final album in _albums) {
         bool flag = false;
         if (object.albumName == album.albumName &&
             object.albumArtistName == album.albumArtistName) {
-          for (int index = 0; index < album.tracks.length; index++) {
-            if (object.uri.toFilePath() ==
-                album.tracks[index].uri.toFilePath()) {
-              album.tracks.removeAt(index);
+          for (final track in album.tracks) {
+            if (object.uri.toFilePath() == track.uri.toFilePath()) {
+              album.tracks.remove(track);
               if (album.tracks.isEmpty) {
-                albums.removeAt(i);
+                _albums.remove(album);
                 flag = true;
               }
               break;
@@ -295,32 +283,22 @@ class Collection extends ChangeNotifier {
         }
       }
       for (String artistName in object.trackArtistNames) {
-        for (Artist artist in artists) {
+        for (Artist artist in _artists) {
           if (artistName == artist.artistName) {
-            for (int index = 0; index < artist.tracks.length; index++) {
-              if (object.uri.toFilePath() ==
-                  artist.tracks[index].uri.toFilePath()) {
-                artist.tracks.removeAt(index);
-                break;
-              }
-            }
+            artist.tracks.removeWhere((element) =>
+                object.uri.toFilePath() == element.uri.toFilePath());
             if (artist.tracks.isEmpty) {
-              artists.remove(artist);
+              _artists.remove(artist);
               break;
             } else {
               for (Album album in artist.albums) {
                 if (object.albumName == album.albumName &&
                     object.albumArtistName == album.albumArtistName) {
-                  for (int index = 0; index < album.tracks.length; index++) {
-                    if (object.trackName == album.tracks[index].trackName) {
-                      album.tracks.removeAt(index);
-                      if (artist.albums.isEmpty) artists.remove(artist);
-                      break;
-                    }
-                  }
+                  album.tracks.removeWhere((element) => element == object);
                   break;
                 }
               }
+              artist.albums.removeWhere((element) => element.tracks.isEmpty);
             }
             break;
           }
@@ -339,27 +317,15 @@ class Collection extends ChangeNotifier {
       if (albumArtists[AlbumArtist(object.albumArtistName)]!.isEmpty) {
         albumArtists.remove(AlbumArtist(object.albumArtistName));
       }
-      files.remove(object.uri.toFilePath());
       if (delete && await File(object.uri.toFilePath()).exists_()) {
         await File(object.uri.toFilePath()).delete_();
       }
     } else if (object is Album) {
-      for (int index = 0; index < albums.length; index++) {
-        if (object.albumName == albums[index].albumName &&
-            object.albumArtistName == albums[index].albumArtistName) {
-          albums.removeAt(index);
-          break;
-        }
-      }
-      List<Track> _tracks = <Track>[];
-      for (final track in tracks) {
-        if (object.albumName != track.albumName &&
-            object.albumArtistName != track.albumArtistName) {
-          _tracks.add(track);
-        }
-      }
-      tracks = _tracks;
-      for (final artist in artists) {
+      _albums.remove(object);
+      _tracks.removeWhere((track) =>
+          object.albumName != track.albumName &&
+          object.albumArtistName != track.albumArtistName);
+      for (final artist in _artists) {
         List<Track> _tracks = <Track>[];
         for (final track in artist.tracks) {
           if (object.albumName != track.albumName &&
@@ -381,9 +347,6 @@ class Collection extends ChangeNotifier {
       if (albumArtists[AlbumArtist(object.albumArtistName)]!.isEmpty) {
         albumArtists.remove(AlbumArtist(object.albumArtistName));
       }
-      for (final track in object.tracks) {
-        files.remove(track);
-      }
       if (delete) {
         for (Track track in object.tracks) {
           if (await File(track.uri.toFilePath()).exists_()) {
@@ -392,7 +355,7 @@ class Collection extends ChangeNotifier {
         }
       }
     }
-    await saveToCache();
+    await Future.wait([sort(), saveToCache()]);
     notifyListeners();
   }
 
@@ -405,7 +368,7 @@ class Collection extends ChangeNotifier {
             .write_(
           encoder.convert(
             {
-              'tracks': tracks.map((e) => e.toJson()).toList(),
+              'tracks': _tracks.map((e) => e.toJson()).toList(),
             },
           ),
         ),
@@ -413,7 +376,7 @@ class Collection extends ChangeNotifier {
             .write_(
           encoder.convert(
             {
-              'albums': albums.map((e) => e.toJson()).toList(),
+              'albums': _albums.map((e) => e.toJson()).toList(),
             },
           ),
         ),
@@ -421,7 +384,7 @@ class Collection extends ChangeNotifier {
             .write_(
           encoder.convert(
             {
-              'artists': artists.map((e) => e.toJson()).toList(),
+              'artists': _artists.map((e) => e.toJson()).toList(),
             },
           ),
         ),
@@ -446,8 +409,7 @@ class Collection extends ChangeNotifier {
     void Function(int? completed, int total, bool isCompleted)? onProgress,
     bool update = true,
   }) async {
-    if (_refreshing) return;
-    _refreshing = true;
+    onProgress?.call(null, 1 << 32, false);
     // For safety.
     if (!await cacheDirectory.exists_())
       await cacheDirectory.create(recursive: true);
@@ -455,10 +417,9 @@ class Collection extends ChangeNotifier {
       if (!await directory.exists_()) await directory.create(recursive: true);
     }
     // Clear existing indexed music.
-    albums = <Album>[];
-    tracks = <Track>[];
-    artists = <Artist>[];
-    files = <String>[];
+    _albums = HashSet<Album>();
+    _tracks = HashSet<Track>();
+    _artists = HashSet<Artist>();
     // Indexing from scratch if no cache exists.
     if (!await File(
             path.join(cacheDirectory.path, kCollectionTrackCacheFileName))
@@ -468,109 +429,94 @@ class Collection extends ChangeNotifier {
     // Just check for newly added or deleted tracks if cache exists.
     else {
       try {
-        // Index tracks already in the cache.
+        // Index tracks, albums & artists already in the cache.
         await Future.wait(
           [
-            (() async => tracks = convert
+            (() async => _tracks = HashSet<Track>.from(convert
                 .jsonDecode(await File(path.join(
                         cacheDirectory.path, kCollectionTrackCacheFileName))
                     .readAsString())['tracks']
-                .map((e) => Track.fromJson(e))
-                .toList()
-                .cast<Track>())(),
-            (() async => albums = convert
-                .jsonDecode(await File(path.join(
-                        cacheDirectory.path, kCollectionAlbumCacheFileName))
-                    .readAsString())['albums']
-                .map((e) {
+                .map((e) => Track.fromJson(e))))(),
+            (() async => _albums = HashSet<Album>.from(convert
+                    .jsonDecode(await File(path.join(
+                            cacheDirectory.path, kCollectionAlbumCacheFileName))
+                        .readAsString())['albums']
+                    .map((e) {
                   final album = Album.fromJson(e);
                   if (!albumArtists
                       .containsKey(AlbumArtist(album.albumArtistName))) {
                     albumArtists[AlbumArtist(album.albumArtistName)] = [];
                   }
                   return album;
-                })
-                .toList()
-                .cast<Album>())(),
-            (() async => artists = convert
+                })))(),
+            (() async => _artists = HashSet<Artist>.from(convert
                 .jsonDecode(await File(path.join(
                         cacheDirectory.path, kCollectionArtistCacheFileName))
                     .readAsString())['artists']
-                .map((e) => Artist.fromJson(e))
-                .toList()
-                .cast<Artist>())(),
+                .map((e) => Artist.fromJson(e))))(),
           ],
         );
+        await sort();
         await _arrangeArtists();
+        await playlistsGetFromCache();
+        notifyListeners();
         // Check for newly added & deleted [Track]s in asynchronous suspension & update the [Collection] accordingly.
         if (update) {
-          () async {
-            // Remove deleted tracks.
-            final buffer = [...tracks];
-            for (final track in buffer) {
-              if (!await File(track.uri.toFilePath()).exists_()) delete(track);
+          // Remove deleted tracks.
+          final tracks = [..._tracks];
+          final files = [..._tracks.map((e) => e.uri.toFilePath())];
+          for (int i = 0; i < files.length; i++) {
+            if (!await File(files[i]).exists_()) {
+              await delete(tracks[i]);
             }
-            // Add newly added tracks.
-            final directory = <File>[];
-            for (Directory collectionDirectory in collectionDirectories) {
-              for (final object in await collectionDirectory.list_()) {
-                directory.add(object);
-              }
+          }
+          // Add newly added tracks.
+          final directory = <File>[];
+          for (Directory collectionDirectory in collectionDirectories) {
+            for (final object in await collectionDirectory.list_()) {
+              directory.add(object);
             }
-            directory.sort((first, second) =>
-                first.lastModifiedSync().compareTo(second.lastModifiedSync()));
-            for (int index = 0; index < directory.length; index++) {
-              File file = directory[index];
-              // Add new tracks.
-              if (!files.contains(file.uri.toFilePath())) {
+          }
+          for (int index = 0; index < directory.length; index++) {
+            File file = directory[index];
+            if (files.contains(file.path)) {
+              continue;
+            }
+            // Add new tracks.
+            try {
+              final metadata = <String, dynamic>{
+                'uri': file.uri.toString(),
+              };
+              if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
                 try {
-                  final metadata = <String, dynamic>{
-                    'uri': file.uri.toString(),
-                  };
-                  if (Platform.isWindows ||
-                      Platform.isLinux ||
-                      Platform.isMacOS) {
-                    try {
-                      metadata.addAll(await tagger.parse(
-                        libmpv.Media(file.uri.toString()),
-                        coverDirectory: albumArtDirectory,
-                        timeout: Duration(seconds: 2),
-                      ));
-                    } catch (exception, stacktrace) {
-                      debugPrint(exception.toString());
-                      debugPrint(stacktrace.toString());
-                    }
-                    final track = Track.fromTagger(metadata);
-                    await _arrange(
-                      track,
-                    );
-                  } else {
-                    final _metadata = await MetadataRetriever.fromUri(
-                      file.uri,
-                      coverDirectory: albumArtDirectory,
-                    );
-                    metadata.addAll(_metadata.toJson().cast());
-                    final track = Track.fromJson(metadata);
-                    await _arrange(
-                      track,
-                    );
-                  }
+                  metadata.addAll(await tagger.parse(
+                    libmpv.Media(file.uri.toString()),
+                    coverDirectory: albumArtDirectory,
+                    timeout: Duration(seconds: 2),
+                  ));
                 } catch (exception, stacktrace) {
                   debugPrint(exception.toString());
                   debugPrint(stacktrace.toString());
                 }
-              } else {}
-              // try {
-              //   onProgress?.call(index + 1, directory.length, false);
-              // } catch (exception) {}
+                final track = Track.fromTagger(metadata);
+                await _arrange(track);
+              } else {
+                final _metadata = await MetadataRetriever.fromUri(
+                  file.uri,
+                  coverDirectory: albumArtDirectory,
+                );
+                metadata.addAll(_metadata.toJson().cast());
+                final track = Track.fromJson(metadata);
+                await _arrange(track);
+              }
+            } catch (exception, stacktrace) {
+              debugPrint(exception.toString());
+              debugPrint(stacktrace.toString());
             }
-            // Cause UI redraw.
             try {
-              onProgress?.call(directory.length, directory.length, true);
+              onProgress?.call(index + 1, directory.length, false);
             } catch (exception) {}
-            // Save to cache.
-            await saveToCache();
-          }();
+          }
         }
       } catch (exception, stacktrace) {
         // Handle corrupt cache.
@@ -579,10 +525,13 @@ class Collection extends ChangeNotifier {
         index(onProgress: onProgress);
       }
     }
-    await playlistsGetFromCache();
-    notifyListeners();
-    print('🌈🌈🌈');
-    _refreshing = false;
+    // Cause UI redraw.
+    try {
+      onProgress?.call(1 << 32, 1 << 32, true);
+    } catch (exception) {}
+    // Save to cache.
+    await sort();
+    await saveToCache();
   }
 
   /// Sorts the music collection contents based upon passed [type].
@@ -593,27 +542,34 @@ class Collection extends ChangeNotifier {
     } else {
       collectionSortType = type;
     }
+    tracks = _tracks.toList();
     tracks.sort((first, second) => (first.timeAdded.millisecondsSinceEpoch)
         .compareTo(second.timeAdded.millisecondsSinceEpoch));
+    albums = _albums.toList();
     albums.sort((first, second) => first.timeAdded.compareTo(second.timeAdded));
     if (type == CollectionSort.aToZ ||
         type ==
             CollectionSort
                 .artist /* Handled externally & applicable only for albums & other tabs fallback to `CollectionSort.aToZ */) {
+      tracks = _tracks.toList();
       tracks.sort((first, second) => first.trackName
           .toLowerCase()
           .compareTo(second.trackName.toLowerCase()));
+      albums = _albums.toList();
       albums.sort((first, second) => first.albumName
           .toLowerCase()
           .compareTo(second.albumName.toLowerCase()));
     }
     if (type == CollectionSort.year) {
+      tracks = _tracks.toList();
       tracks.sort((first, second) => (int.tryParse(first.year) ?? -1)
           .compareTo(int.tryParse(second.year) ?? -1));
+      albums = _albums.toList();
       albums.sort((first, second) => (int.tryParse(first.year) ?? -1)
           .compareTo(int.tryParse(second.year) ?? -1));
     }
     // Only `CollectionSort.aToZ` is available for [artists].
+    artists = _artists.toList();
     artists.sort((first, second) => first.artistName
         .toLowerCase()
         .compareTo(second.artistName.toLowerCase()));
@@ -647,10 +603,9 @@ class Collection extends ChangeNotifier {
   Future<void> index(
       {void Function(int? completed, int total, bool isCompleted)?
           onProgress}) async {
-    albums = <Album>[];
-    tracks = <Track>[];
-    artists = <Artist>[];
-    files = <String>[];
+    _albums = HashSet<Album>();
+    _tracks = HashSet<Track>();
+    _artists = HashSet<Artist>();
     playlists = <Playlist>[];
     final directory = <File>[];
     onProgress?.call(null, directory.length, true);
@@ -862,9 +817,7 @@ class Collection extends ChangeNotifier {
   /// Indexes a track into album & artist models.
   ///
   Future<void> _arrange(Track track) async {
-    if (files.contains(track.uri.toFilePath())) return;
-    files.add(track.uri.toFilePath());
-    if (!albums.contains(
+    if (!_albums.contains(
       Album(
         albumName: track.albumName,
         albumArtistName: track.albumArtistName,
@@ -872,7 +825,7 @@ class Collection extends ChangeNotifier {
       ),
     )) {
       // Run as asynchronous suspension.
-      albums.add(
+      _albums.add(
         Album(
           albumName: track.albumName,
           year: track.year,
@@ -880,14 +833,13 @@ class Collection extends ChangeNotifier {
         )..tracks.add(track),
       );
     } else {
-      albums[albums.indexOf(
-        Album(
-          albumName: track.albumName,
-          albumArtistName: track.albumArtistName,
-          year: track.year,
-        ),
-      )]
-          .tracks
+      _albums
+          .lookup(Album(
+            albumName: track.albumName,
+            albumArtistName: track.albumArtistName,
+            year: track.year,
+          ))
+          ?.tracks
           .add(track);
     }
     // A new album artist gets discovered.
@@ -896,41 +848,35 @@ class Collection extends ChangeNotifier {
       albumArtists[AlbumArtist(track.albumArtistName)] = [];
     }
     for (String artistName in track.trackArtistNames) {
-      if (!artists.contains(Artist(artistName: artistName))) {
-        artists.add(
+      if (!_artists.contains(Artist(artistName: artistName))) {
+        _artists.add(
           Artist(
             artistName: artistName,
           )..tracks.add(track),
         );
       } else {
-        artists[artists.indexOf(
-          Artist(artistName: artistName),
-        )]
-            .tracks
-            .add(track);
+        _artists.lookup(Artist(artistName: artistName))?.tracks.add(track);
       }
     }
-    tracks.add(track);
+    _tracks.add(track);
   }
 
   /// Populates all the [albumArtists] & discovered artists' albums after running the [_arrange] loop.
   ///
   Future<void> _arrangeArtists() async {
-    for (Album album in albums) {
-      List<String> allAlbumArtistNames = <String>[];
+    for (final album in _albums) {
+      final all = <String>[];
       album.tracks.forEach((Track track) {
         track.trackArtistNames.forEach((artistName) {
-          if (!allAlbumArtistNames.contains(artistName))
-            allAlbumArtistNames.add(artistName);
+          if (!all.contains(artistName)) all.add(artistName);
         });
       });
-      for (String artistName in allAlbumArtistNames) {
-        if (!artists[artists.indexOf(Artist(artistName: artistName))]
+      for (final artistName in all) {
+        if (!_artists
+            .lookup(Artist(artistName: artistName))!
             .albums
             .contains(album))
-          artists[artists.indexOf(Artist(artistName: artistName))]
-              .albums
-              .add(album);
+          _artists.lookup(Artist(artistName: artistName))!.albums.add(album);
       }
       if (!albumArtists[AlbumArtist(album.albumArtistName)]!.contains(album)) {
         albumArtists[AlbumArtist(album.albumArtistName)]!.add(album);
@@ -944,7 +890,7 @@ class Collection extends ChangeNotifier {
   Future<void> redraw() async {
     await sort();
     // Explicitly populate so that [Artist] sort in [Album] tab doesn't present empty screen at the time of indexing.
-    for (Album album in albums) {
+    for (Album album in _albums) {
       if (!albumArtists[AlbumArtist(album.albumArtistName)]!.contains(album)) {
         albumArtists[AlbumArtist(album.albumArtistName)]!.add(album);
       }
@@ -955,6 +901,10 @@ class Collection extends ChangeNotifier {
   @override
   // ignore: must_call_super
   void dispose() {}
+
+  HashSet<Album> _albums = HashSet<Album>();
+  HashSet<Track> _tracks = HashSet<Track>();
+  HashSet<Artist> _artists = HashSet<Artist>();
 }
 
 /// Types of sorts available.

--- a/lib/interface/collection/album.dart
+++ b/lib/interface/collection/album.dart
@@ -607,11 +607,13 @@ class AlbumScreenState extends State<AlbumScreen>
   bool detailsLoaded = false;
   ScrollController controller = ScrollController(initialScrollOffset: 136.0);
   ScrollPhysics? physics = NeverScrollableScrollPhysics();
+  late List<Track> tracks;
 
   @override
   void initState() {
+    tracks = widget.album.tracks.toList();
     super.initState();
-    widget.album.tracks.sort(
+    tracks.sort(
         (first, second) => first.trackNumber.compareTo(second.trackNumber));
     if (isDesktop) {
       Timer(
@@ -835,7 +837,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                               ),
                                               SizedBox(height: 8.0),
                                               Text(
-                                                '${Language.instance.ARTIST}: ${widget.album.albumArtistName}\n${Language.instance.YEAR}: ${widget.album.year}\n${Language.instance.TRACK}: ${widget.album.tracks.length}',
+                                                '${Language.instance.ARTIST}: ${widget.album.albumArtistName}\n${Language.instance.YEAR}: ${widget.album.year}\n${Language.instance.TRACK}: ${tracks.length}',
                                                 style: Theme.of(context)
                                                     .textTheme
                                                     .headline3,
@@ -854,7 +856,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                                 heroTag: 'play_now',
                                                 onPressed: () {
                                                   Playback.instance.open([
-                                                    ...widget.album.tracks,
+                                                    ...tracks,
                                                     if (Configuration.instance
                                                         .seamlessPlayback)
                                                       ...[
@@ -877,7 +879,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                                 heroTag: 'add_to_now_playing',
                                                 onPressed: () {
                                                   Playback.instance.add(
-                                                    widget.album.tracks,
+                                                    tracks,
                                                   );
                                                 },
                                                 mini: true,
@@ -952,7 +954,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                               ),
                                               Divider(height: 1.0),
                                             ] +
-                                            (widget.album.tracks
+                                            (tracks
                                                 .asMap()
                                                 .entries
                                                 .map(
@@ -1064,7 +1066,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                                                           Playback
                                                                               .instance
                                                                               .open(
-                                                                            widget.album.tracks,
+                                                                            tracks,
                                                                             index:
                                                                                 track.key,
                                                                           );
@@ -1436,7 +1438,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                       child: Icon(Icons.play_arrow),
                                       onPressed: () {
                                         Playback.instance.open([
-                                          ...widget.album.tracks,
+                                          ...tracks,
                                           if (Configuration
                                               .instance.seamlessPlayback)
                                             ...[...Collection.instance.tracks]
@@ -1476,7 +1478,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                       child: Icon(Icons.shuffle),
                                       onPressed: () {
                                         Playback.instance.open(
-                                          [...widget.album.tracks]..shuffle(),
+                                          [...tracks]..shuffle(),
                                         );
                                       },
                                     ),
@@ -1499,7 +1501,7 @@ class AlbumScreenState extends State<AlbumScreen>
                             child: InkWell(
                               onTap: () => Playback.instance.open(
                                 [
-                                  ...widget.album.tracks,
+                                  ...tracks,
                                   if (Configuration.instance.seamlessPlayback)
                                     ...[...Collection.instance.tracks]
                                       ..shuffle(),
@@ -1526,10 +1528,10 @@ class AlbumScreenState extends State<AlbumScreen>
                                 );
                                 await trackPopupMenuHandle(
                                   context,
-                                  widget.album.tracks[i],
+                                  tracks[i],
                                   result,
                                   recursivelyPopNavigatorOnDeleteIf: () =>
-                                      widget.album.tracks.isEmpty,
+                                      tracks.isEmpty,
                                 );
                               },
                               child: Column(
@@ -1550,7 +1552,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                           width: 56.0,
                                           alignment: Alignment.center,
                                           child: Text(
-                                            '${widget.album.tracks[i].trackNumber}',
+                                            '${tracks[i].trackNumber}',
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .headline3
@@ -1567,8 +1569,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                                 CrossAxisAlignment.start,
                                             children: [
                                               Text(
-                                                widget.album.tracks[i].trackName
-                                                    .overflow,
+                                                tracks[i].trackName.overflow,
                                                 overflow: TextOverflow.ellipsis,
                                                 maxLines: 1,
                                                 style: Theme.of(context)
@@ -1579,12 +1580,11 @@ class AlbumScreenState extends State<AlbumScreen>
                                                 height: 2.0,
                                               ),
                                               Text(
-                                                (widget.album.tracks[i]
-                                                                .duration ??
+                                                (tracks[i].duration ??
                                                             Duration.zero)
                                                         .label +
                                                     ' • ' +
-                                                    widget.album.tracks[i]
+                                                    tracks[i]
                                                         .trackArtistNames
                                                         .take(2)
                                                         .join(', '),
@@ -1630,7 +1630,7 @@ class AlbumScreenState extends State<AlbumScreen>
                                               );
                                               await trackPopupMenuHandle(
                                                 context,
-                                                widget.album.tracks[i],
+                                                tracks[i],
                                                 result,
                                                 recursivelyPopNavigatorOnDeleteIf:
                                                     () => widget
@@ -1655,7 +1655,7 @@ class AlbumScreenState extends State<AlbumScreen>
                               ),
                             ),
                           ),
-                          childCount: widget.album.tracks.length,
+                          childCount: tracks.length,
                         ),
                       ),
                       SliverPadding(

--- a/lib/interface/collection/artist.dart
+++ b/lib/interface/collection/artist.dart
@@ -427,6 +427,7 @@ class ArtistScreenState extends State<ArtistScreen>
 
   @override
   Widget build(BuildContext context) {
+    final tracks = widget.artist.tracks.toList();
     return Consumer<Collection>(
       builder: (context, collection, _) => isDesktop
           ? Scaffold(
@@ -564,7 +565,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                                 ),
                                                 SizedBox(height: 8.0),
                                                 Text(
-                                                  '${Language.instance.TRACK}: ${widget.artist.tracks.length}\n${Language.instance.ALBUM}: ${widget.artist.albums.length}',
+                                                  '${Language.instance.TRACK}: ${tracks.length}\n${Language.instance.ALBUM}: ${widget.artist.albums.length}',
                                                   style: Theme.of(context)
                                                       .textTheme
                                                       .headline3,
@@ -585,7 +586,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                                   onPressed: () {
                                                     Playback.instance.open(
                                                       [
-                                                        ...widget.artist.tracks,
+                                                        ...tracks,
                                                         if (Configuration
                                                             .instance
                                                             .seamlessPlayback)
@@ -610,7 +611,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                                   heroTag: 'add_to_now_playing',
                                                   onPressed: () {
                                                     Playback.instance.add(
-                                                      widget.artist.tracks,
+                                                      tracks.toList(),
                                                     );
                                                   },
                                                   mini: true,
@@ -694,7 +695,8 @@ class ArtistScreenState extends State<ArtistScreen>
                                                 ),
                                                 Divider(height: 1.0),
                                               ] +
-                                              widget.artist.tracks
+                                              tracks
+                                                  .toList()
                                                   .asMap()
                                                   .entries
                                                   .map(
@@ -807,7 +809,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                                                               () {
                                                                             Playback.instance.open(
                                                                               [
-                                                                                ...widget.artist.tracks,
+                                                                                ...tracks,
                                                                                 if (Configuration.instance.seamlessPlayback)
                                                                                   ...[
                                                                                     ...Collection.instance.tracks
@@ -1087,8 +1089,8 @@ class ArtistScreenState extends State<ArtistScreen>
                                               Text(
                                                 Language.instance
                                                     .M_TRACKS_AND_N_ALBUMS
-                                                    .replaceAll('M',
-                                                        '${widget.artist.tracks.length}')
+                                                    .replaceAll(
+                                                        'M', '${tracks.length}')
                                                     .replaceAll('N',
                                                         '${widget.artist.albums.length}'),
                                                 overflow: TextOverflow.ellipsis,
@@ -1145,7 +1147,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                         child: Icon(Icons.play_arrow),
                                         onPressed: () {
                                           Playback.instance.open([
-                                            ...widget.artist.tracks,
+                                            ...tracks,
                                             if (Configuration
                                                 .instance.seamlessPlayback)
                                               ...[...Collection.instance.tracks]
@@ -1187,8 +1189,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                         child: Icon(Icons.shuffle),
                                         onPressed: () {
                                           Playback.instance.open(
-                                            [...widget.artist.tracks]
-                                              ..shuffle(),
+                                            [...tracks]..shuffle(),
                                             index: 0,
                                           );
                                         },
@@ -1212,7 +1213,7 @@ class ArtistScreenState extends State<ArtistScreen>
                               child: InkWell(
                                 onTap: () => Playback.instance.open(
                                   [
-                                    ...widget.artist.tracks,
+                                    ...tracks,
                                     if (Configuration.instance.seamlessPlayback)
                                       ...[...Collection.instance.tracks]
                                         ..shuffle(),
@@ -1240,10 +1241,10 @@ class ArtistScreenState extends State<ArtistScreen>
                                   );
                                   await trackPopupMenuHandle(
                                     context,
-                                    widget.artist.tracks[i],
+                                    tracks[i],
                                     result,
                                     recursivelyPopNavigatorOnDeleteIf: () =>
-                                        widget.artist.tracks.isEmpty,
+                                        tracks.isEmpty,
                                   );
                                 },
                                 child: Column(
@@ -1264,7 +1265,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                             width: 56.0,
                                             alignment: Alignment.center,
                                             child: Text(
-                                              '${widget.artist.tracks[i].trackNumber}',
+                                              '${tracks[i].trackNumber}',
                                               style: Theme.of(context)
                                                   .textTheme
                                                   .headline3
@@ -1281,8 +1282,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                                   CrossAxisAlignment.start,
                                               children: [
                                                 Text(
-                                                  widget.artist.tracks[i]
-                                                      .trackName.overflow,
+                                                  tracks[i].trackName.overflow,
                                                   overflow:
                                                       TextOverflow.ellipsis,
                                                   maxLines: 1,
@@ -1294,13 +1294,11 @@ class ArtistScreenState extends State<ArtistScreen>
                                                   height: 2.0,
                                                 ),
                                                 Text(
-                                                  (widget.artist.tracks[i]
-                                                                  .duration ??
+                                                  (tracks[i].duration ??
                                                               Duration.zero)
                                                           .label +
                                                       ' • ' +
-                                                      widget.artist.tracks[i]
-                                                          .albumName,
+                                                      tracks[i].albumName,
                                                   overflow:
                                                       TextOverflow.ellipsis,
                                                   maxLines: 1,
@@ -1345,11 +1343,10 @@ class ArtistScreenState extends State<ArtistScreen>
                                                 );
                                                 await trackPopupMenuHandle(
                                                   context,
-                                                  widget.artist.tracks[i],
+                                                  tracks[i],
                                                   result,
                                                   recursivelyPopNavigatorOnDeleteIf:
-                                                      () => widget.artist.tracks
-                                                          .isEmpty,
+                                                      () => tracks.isEmpty,
                                                 );
                                               },
                                               icon: Icon(
@@ -1370,7 +1367,7 @@ class ArtistScreenState extends State<ArtistScreen>
                                 ),
                               ),
                             ),
-                            childCount: widget.artist.tracks.length,
+                            childCount: tracks.length,
                           ),
                         ),
                         SliverPadding(

--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -12,7 +12,7 @@ class Album extends Media {
   String albumName;
   String year;
   String albumArtistName;
-  final tracks = <Track>[];
+  final HashSet<Track> tracks = HashSet<Track>();
 
   @override
   Map<String, dynamic> toJson() => {
@@ -27,10 +27,7 @@ class Album extends Media {
         year: json['year'] ?? kUnknownYear,
         albumArtistName: json['albumArtistName'] ?? kUnknownArtist,
       )..tracks.addAll(
-          json['tracks'] != null
-              ? (json['tracks'] as List).map((e) => Track.fromJson(e))
-              : [],
-        );
+          json['tracks']?.map((e) => Track.fromJson(e))?.cast<Track>() ?? []);
 
   Album({
     required this.albumName,

--- a/lib/models/artist.dart
+++ b/lib/models/artist.dart
@@ -10,8 +10,8 @@ part of 'media.dart';
 
 class Artist extends Media {
   final String artistName;
-  final tracks = <Track>[];
-  final albums = <Album>[];
+  final HashSet<Track> tracks = HashSet<Track>();
+  final HashSet<Album> albums = HashSet<Album>();
 
   @override
   Map<String, dynamic> toJson() => {
@@ -24,15 +24,9 @@ class Artist extends Media {
         artistName: json['artistName'] ?? kUnknownArtist,
       )
         ..tracks.addAll(
-          json['tracks'] != null
-              ? (json['tracks'] as List).map((e) => Track.fromJson(e))
-              : [],
-        )
+            json['tracks']?.map((e) => Track.fromJson(e))?.cast<Track>() ?? [])
         ..albums.addAll(
-          json['tracks'] != null
-              ? (json['tracks'] as List).map((e) => Album.fromJson(e))
-              : [],
-        );
+            json['albums']?.map((e) => Album.fromJson(e))?.cast<Album>() ?? []);
 
   Artist({
     required this.artistName,

--- a/lib/models/media.dart
+++ b/lib/models/media.dart
@@ -7,6 +7,7 @@
 ///
 
 import 'dart:io';
+import 'dart:collection';
 import 'package:libmpv/libmpv.dart';
 import 'package:path/path.dart' as path;
 
@@ -26,9 +27,7 @@ abstract class Media {
   Map<String, dynamic> toJson();
 
   @override
-  bool operator ==(Object media) {
-    throw UnimplementedError();
-  }
+  bool operator ==(Object media) => throw UnimplementedError();
 
   @override
   int get hashCode => throw UnimplementedError();

--- a/lib/utils/file_system.dart
+++ b/lib/utils/file_system.dart
@@ -46,7 +46,7 @@ extension DirectoryExtension on Directory {
       },
       onError: (error) {
         // For debugging. In case any future error is reported.
-        debugPrint('Directory.list_: ${error}');
+        debugPrint(error.toString());
       },
       onDone: completer.complete,
     );
@@ -65,29 +65,38 @@ extension FileExtension on File {
   ///
   /// Thanks to @raitonoberu for the idea.
   ///
-  Future<File> write_(String content) async {
-    final prefix = Platform.isWindows &&
-            !path.startsWith('\\\\') &&
-            !path.startsWith(r'\\?\')
-        ? r'\\?\'
-        : '';
-    final file = File(join(prefix + parent.path, 'Temp', const Uuid().v4()));
-    if (!await file.exists_()) {
-      await file.create(recursive: true);
+  Future<void> write_(String content) async {
+    try {
+      final prefix = Platform.isWindows &&
+              !path.startsWith('\\\\') &&
+              !path.startsWith(r'\\?\')
+          ? r'\\?\'
+          : '';
+      final file = File(join(prefix + parent.path, 'Temp', const Uuid().v4()));
+      if (!await file.exists_()) {
+        await file.create(recursive: true);
+      }
+      await file.writeAsString(content, flush: true);
+      await file.rename_(prefix + path);
+    } catch (exception, stacktrace) {
+      debugPrint(exception.toString());
+      debugPrint(stacktrace.toString());
     }
-    await file.writeAsString(content, flush: true);
-    await file.rename_(prefix + path);
-    return this;
   }
 
   /// Safely [rename]s a [File].
-  FutureOr<File> rename_(String newPath) {
-    final prefix = Platform.isWindows &&
-            !path.startsWith('\\\\') &&
-            !path.startsWith(r'\\?\')
-        ? r'\\?\'
-        : '';
-    return File(prefix + path).rename(newPath);
+  Future<void> rename_(String newPath) async {
+    try {
+      final prefix = Platform.isWindows &&
+              !path.startsWith('\\\\') &&
+              !path.startsWith(r'\\?\')
+          ? r'\\?\'
+          : '';
+      await File(prefix + path).rename(newPath);
+    } catch (exception, stacktrace) {
+      debugPrint(exception.toString());
+      debugPrint(stacktrace.toString());
+    }
   }
 }
 

--- a/lib/utils/rendering.dart
+++ b/lib/utils/rendering.dart
@@ -260,18 +260,19 @@ List<PopupMenuItem<int>> trackPopupMenuItems(BuildContext context) {
         ),
       ),
     ),
-    PopupMenuItem<int>(
-      padding: EdgeInsets.zero,
-      value: 1,
-      child: ListTile(
-        leading: Icon(
-            Platform.isWindows ? FluentIcons.share_16_regular : Icons.share),
-        title: Text(
-          Language.instance.SHARE,
-          style: isDesktop ? Theme.of(context).textTheme.headline4 : null,
+    if (Platform.isAndroid || Platform.isIOS)
+      PopupMenuItem<int>(
+        padding: EdgeInsets.zero,
+        value: 1,
+        child: ListTile(
+          leading: Icon(
+              Platform.isWindows ? FluentIcons.share_16_regular : Icons.share),
+          title: Text(
+            Language.instance.SHARE,
+            style: isDesktop ? Theme.of(context).textTheme.headline4 : null,
+          ),
         ),
       ),
-    ),
     PopupMenuItem<int>(
       padding: EdgeInsets.zero,
       value: 3,


### PR DESCRIPTION
- Now `HashSet<T>` is used as container to keep instances of `Album`, `Track` & `Artist` models.
- Simplified other indexing & sorting logic.
- Improve `refresh` method from `Collection`.
- Address other issues related to `File` I/O.